### PR TITLE
[Proposal] Turn off `react/prop-types` rule to avoid redundant type annotation

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ module.exports = {
         format: ['PascalCase']
       }
     ],
+    'react/prop-types': 'off', // @see https://github.com/yannickcr/eslint-plugin-react/issues/2353
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn'
   },


### PR DESCRIPTION
In TypeScript `React.FC` type infer type of props, so the below is type-safe code, but `react/prop-types` violated.

```tsx
export const Foo: React.FC<{ bar: string }> = props => {
  return <>{props.bar}</>; // error  'bar' is missing in props validation  react/prop-types
};
```

related issue: https://github.com/yannickcr/eslint-plugin-react/issues/2353

This proposal is turning off the rule to avoid redundant type annotation.
