### PR TITLE
🔧 Remove quotes rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ module.exports = {
     'plugin:import/typescript'
   ],
   rules: {
-    quotes: ['error', 'single'],
     'no-console': 'warn',
     camelcase: 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',


### PR DESCRIPTION
quotes rule is originally [disabled by eslint-config-prettier](https://github.com/prettier/eslint-config-prettier/blob/main/index.js#L17)


If you enable quotes here, it conflicts with the prettier rules, so you may want to remove it.

e.g.
```
// ESLint (quotes: ['error', 'single'])
const str = 'John\'s';
// prettier (singleQuote: true)
const str = "John's";
```
