### PR TITLE
Bump @typescript-eslint/* from 4.22.0 to 5.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "author": "freee",
   "license": "MIT",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "@typescript-eslint/parser": "^4.22.0",
+    "@typescript-eslint/eslint-plugin": "^5.24.0",
+    "@typescript-eslint/parser": "^5.24.0",
     "eslint": "^7.24.0",
     "eslint-config-prettier": "^8.2.0",
     "eslint-import-resolver-typescript": "^2.4.0",
@@ -27,8 +27,8 @@
     "prettier-config-freee": "^1.1.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "@typescript-eslint/parser": "^4.22.0",
+    "@typescript-eslint/eslint-plugin": "^5.24.0",
+    "@typescript-eslint/parser": "^5.24.0",
     "eslint": "^7.24.0",
     "eslint-config-prettier": "^8.2.0",
     "eslint-import-resolver-typescript": "^2.4.0",


### PR DESCRIPTION
Bump `@typescript-eslint/*` for TypeScript 4.6

Looking at the `plugin:@typescript-eslint/recommended` config difference, it doesn't seem necessary to modify `index.js`.

https://github.com/typescript-eslint/typescript-eslint/compare/v4.22.0...v5.24.0
`packages/eslint-plugin/src/configs/recommended.ts`

