### PR TITLE
🔧 Remove prefer-interface rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ module.exports = {
     camelcase: 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
-    '@typescript-eslint/prefer-interface': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/naming-convention': [
       'error',


### PR DESCRIPTION
Remove `@typescript-eslint/prefer-interface` because it has already been removed in typescript-eslint v2.0.0
https://github.com/typescript-eslint/typescript-eslint/releases/tag/v2.0.0

This rule does not already exist in the `recommended` config.
https://github.com/typescript-eslint/typescript-eslint/blob/v4.22.0/packages/eslint-plugin/src/configs/recommended.ts